### PR TITLE
Add missing @cartridge/presets dependency to controller package

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -43,7 +43,8 @@
     "@starknet-io/types-js": "catalog:",
     "@telegram-apps/sdk": "^2.4.0",
     "cbor-x": "^1.5.0",
-    "fast-deep-equal": "catalog:"
+    "fast-deep-equal": "catalog:",
+    "@cartridge/presets": "^0.5.2"
   },
   "devDependencies": {
     "@cartridge/tsconfig": "workspace:*",


### PR DESCRIPTION
Fix issue where @cartridge/controller requires manual installation of @cartridge/presets

## Problem
The controller package currently exports from @cartridge/presets in its index.d.ts: `export * from '@cartridge/presets';`

However, @cartridge/presets is not listed as a dependency in the controller package.json, requiring users to manually install it.

## Solution
Add @cartridge/presets to the dependencies section of the controller package.json.